### PR TITLE
Implementing xpath RPC helper

### DIFF
--- a/webfriend/info.py
+++ b/webfriend/info.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import
 
-version = '0.2.3'
+version = '0.2.4'


### PR DESCRIPTION
Implements the `xpath()` method in the RPC wrappers and in Friendscript:

Python:
```
with Chrome() as browser:
    commands = Environment(browser=browser)
    commands.core.go('https://news.ycombinator.com')
    print(commands.core.xpath('//a'))
```

Friendscript:
```
go 'https://news.ycombinator.com'
xpath '//a'
```

In both cases, a list of DOMElements should be returned matching the given XPath expression.

Thanks @jamcplusplus for the fix!