### PR TITLE
Updating capture_screenshot and navigation timeout

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -174,11 +174,12 @@ A `bool` value representing whether the tab was closed successfully or not.
 
 ```
 configure <EVENTS> {
-    demo:          null,
-    user_agent:    null,
-    extra_headers: null,
-    cache:         null,
-    console:       null
+    demo:            null,
+    user_agent:      null,
+    extra_headers:   null,
+    cache:           null,
+    console:         null,
+    referrer_domain: null
 }
 ```
 
@@ -220,6 +221,10 @@ setup.
 - **console** (`bool`, optional):
 
     Whether console messages emitted from pages are logged to standard error.
+
+- **referrer_domain** (`str`, optional):
+
+    The domain portion of the "Referer" header to send.
 
 ---
 
@@ -348,11 +353,13 @@ The matching `webfriend.rpc.DOMElement` that was given focus.
 
 ```
 go <URI> {
-    referrer:          'random',
-    wait_for_load:     true,
-    timeout:           30000,
-    clear_requests:    true,
-    continue_on_error: false
+    referrer:            'random',
+    wait_for_load:       true,
+    timeout:             30000,
+    clear_requests:      true,
+    continue_on_error:   false,
+    continue_on_timeout: true,
+    load_event_name:     'Page.loadEventFired'
 }
 ```
 
@@ -383,6 +390,20 @@ Nagivate to a URL.
     Whether the resources stack that is queried in [page::resources](#pageresources) and
     [page::resource](#pageresource) is cleared before navigating.  Set this to _false_ to
     preserve the ability to retrieve data that was loaded on previous pages.
+
+- **continue_on_error** (`bool`, optional):
+
+    Whether to continue execution if an error is encountered during page load (e.g.: HTTP
+    4xx/5xx, SSL, TCP connection errors).
+
+- **continue_on_timeout** (`bool`, optional):
+
+    Whether to continue execution if **load_event_name** is not seen before **timeout**
+    elapses.
+
+- **load_event_name** (`str`, optional):
+
+    The RPC event to wait for before proceeding to the next command.
 
 #### Returns
 The URL that was loaded (`str`)
@@ -1784,7 +1805,8 @@ page::screenshot <DESTINATION> {
     after_events:   null,
     settle_timeout: null,
     reply_timeout:  30000,
-    autoclose:      true
+    autoclose:      true,
+    use:            'tallest'
 }
 ```
 
@@ -1855,6 +1877,16 @@ as a file-like object.
 
     If a file handle is given as the **destination**, should it be automatically closed
     when the screenshot is completed.
+
+- **use** (`str`):
+
+    Determines how to handle multiple elements that are matched by **selector**.
+
+    - "tallest":
+        Use the tallest element as the result for measuring screenshot dimensions.
+
+    - "first":
+        Use the first element matched as the result for measuring screenshot dimensions.
 
 #### Returns
 `dict`, with keys:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -179,7 +179,7 @@ configure <EVENTS> {
     extra_headers:   null,
     cache:           null,
     console:         null,
-    referrer_domain: null
+    referrer_prefix: null
 }
 ```
 
@@ -222,7 +222,7 @@ setup.
 
     Whether console messages emitted from pages are logged to standard error.
 
-- **referrer_domain** (`str`, optional):
+- **referrer_prefix** (`str`, optional):
 
     The domain portion of the "Referer" header to send.
 

--- a/webfriend/exceptions.py
+++ b/webfriend/exceptions.py
@@ -3,7 +3,16 @@ class WebfriendError(Exception):
 
 
 class ProtocolError(WebfriendError):
-    pass
+    def __init__(self, message, **kwargs):
+        if message.startswith('Protocol Error '):
+            try:
+                parts = message.split(':', 1)
+                self.code = int(parts[0].replace('Protocol Error ', ''))
+                message = parts[1]
+            except:
+                self.code = -1
+
+        super(Exception, self).__init__(message, **kwargs)
 
 
 class TimeoutError(WebfriendError):

--- a/webfriend/info.py
+++ b/webfriend/info.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import
 
-version = '0.2.14'
+version = '0.3.0'

--- a/webfriend/rpc/dom.py
+++ b/webfriend/rpc/dom.py
@@ -210,11 +210,7 @@ class DOMElement(object):
     @property
     def bounds(self):
         if self._bounding_rect is None:
-            self._bounding_rect = self.evaluate(
-                "return this.getBoundingClientRect();",
-                return_by_value=True
-            )
-
+            self._bounding_rect = self.evaluate("return this.getBoundingClientRect()")
         return self._bounding_rect
 
     @property
@@ -822,7 +818,7 @@ class DOM(Base):
 
     @classmethod
     def prepare_selector(cls, selector):
-        selector = RX_ID_EXPANSION.sub('*[id*="\g<id>"]', selector)
+        selector = RX_ID_EXPANSION.sub('*[id="\g<id>"]', selector)
 
         return selector
 

--- a/webfriend/rpc/emulation.py
+++ b/webfriend/rpc/emulation.py
@@ -24,10 +24,10 @@ class Emulation(Base):
         device_scale_factor=0,
         mobile=False,
         fit_window=False,
-        mobile_screen_width=0,
-        mobile_screen_height=0,
-        mobile_position_x=0,
-        mobile_position_y=0,
+        position_x=0,
+        position_y=0,
+        screen_width=0,
+        screen_height=0,
         screen_orientation_type=None,
         screen_orientation_angle=None
     ):
@@ -39,11 +39,17 @@ class Emulation(Base):
             'fitWindow':         fit_window,
         }
 
-        if mobile is True:
-            params['screenWidth']  = mobile_screen_width
-            params['screenHeight'] = mobile_screen_height
-            params['positionX']    = mobile_position_x
-            params['positionY']    = mobile_position_y
+        if position_x:
+            params['positionX'] = position_x
+
+        if position_y:
+            params['positionY'] = position_y
+
+        if screen_width:
+            params['screenWidth']  = screen_width
+
+        if screen_height:
+            params['screenHeight'] = screen_height
 
         if screen_orientation_type is not None:
             params['screenOrientation'] = {

--- a/webfriend/rpc/page.py
+++ b/webfriend/rpc/page.py
@@ -82,7 +82,15 @@ class Page(Base):
 
         self.call('handleJavaScriptDialog', **params)
 
-    def capture_screenshot(self, destination, format=None, quality=None, from_surface=True, reply_timeout=None):
+    def capture_screenshot(
+        self,
+        destination,
+        format=None,
+        quality=None,
+        from_surface=True,
+        reply_timeout=None,
+        clip=None
+    ):
         params = {}
 
         if format is not None:
@@ -98,6 +106,9 @@ class Page(Base):
 
         if from_surface is False:
             params['fromSurface'] = False
+
+        if isinstance(clip, dict):
+            params['clip'] = clip
 
         reply = self.call('captureScreenshot', reply_timeout=reply_timeout, **params)
 

--- a/webfriend/scripting/commands/core.py
+++ b/webfriend/scripting/commands/core.py
@@ -24,7 +24,7 @@ class CoreProxy(CommandProxy):
     These represent very common tasks that one is likely to perform in a browser, such as
     navigating to URLs, filling in form fields, and performing input with the mouse and keyboard.
     """
-    default_referrer_domain = 'https://github.com/ghetzel/webfriend'
+    default_referrer_prefix = 'https://github.com/ghetzel/webfriend'
 
     @classmethod
     def qualify(cls, name):
@@ -38,7 +38,7 @@ class CoreProxy(CommandProxy):
         extra_headers=None,
         cache=None,
         console=None,
-        referrer_domain=None
+        referrer_prefix=None
     ):
         """
         Configures various features of the Remote Debugging protocol and provides environment
@@ -80,7 +80,7 @@ class CoreProxy(CommandProxy):
 
             Whether console messages emitted from pages are logged to standard error.
 
-        - **referrer_domain** (`str`, optional):
+        - **referrer_prefix** (`str`, optional):
 
             The domain portion of the "Referer" header to send.
         """
@@ -118,10 +118,10 @@ class CoreProxy(CommandProxy):
         else:
             self.tab.disable_console_messages()
 
-        if referrer_domain:
-            self._referrer_domain = referrer_domain
+        if referrer_prefix:
+            self._referrer_prefix = referrer_prefix
         else:
-            self._referrer_domain = self.default_referrer_domain
+            self._referrer_prefix = self.default_referrer_prefix
 
     def go(
         self,
@@ -183,7 +183,7 @@ class CoreProxy(CommandProxy):
 
         if referrer is 'random':
             referrer = '{}/{}'.format(
-                self._referrer_domain.rstrip('/'),
+                self._referrer_prefix.rstrip('/'),
                 uuid4()
             )
 

--- a/webfriend/scripting/commands/core.py
+++ b/webfriend/scripting/commands/core.py
@@ -195,8 +195,8 @@ class CoreProxy(CommandProxy):
 
         if not len(uri_p.scheme):
             uri = 'https://{}'.format(uri)
-
-        uri = urlnorm.norm(uri)
+        elif uri_p.scheme != 'file':
+            uri = urlnorm.norm(uri)
 
         reply = self.tab.page.navigate(uri, referrer=referrer)
 

--- a/webfriend/scripting/commands/core.py
+++ b/webfriend/scripting/commands/core.py
@@ -24,6 +24,7 @@ class CoreProxy(CommandProxy):
     These represent very common tasks that one is likely to perform in a browser, such as
     navigating to URLs, filling in form fields, and performing input with the mouse and keyboard.
     """
+    default_referrer_domain = 'https://github.com/ghetzel/webfriend'
 
     @classmethod
     def qualify(cls, name):
@@ -36,7 +37,8 @@ class CoreProxy(CommandProxy):
         user_agent=None,
         extra_headers=None,
         cache=None,
-        console=None
+        console=None,
+        referrer_domain=None
     ):
         """
         Configures various features of the Remote Debugging protocol and provides environment
@@ -77,6 +79,10 @@ class CoreProxy(CommandProxy):
         - **console** (`bool`, optional):
 
             Whether console messages emitted from pages are logged to standard error.
+
+        - **referrer_domain** (`str`, optional):
+
+            The domain portion of the "Referer" header to send.
         """
         if events and hasattr(events, 'values') and isinstance(events.values, list):
             for domain in events.values:
@@ -112,6 +118,11 @@ class CoreProxy(CommandProxy):
         else:
             self.tab.disable_console_messages()
 
+        if referrer_domain:
+            self._referrer_domain = referrer_domain
+        else:
+            self._referrer_domain = self.default_referrer_domain
+
     def go(
         self,
         uri,
@@ -119,7 +130,9 @@ class CoreProxy(CommandProxy):
         wait_for_load=True,
         timeout=30000,
         clear_requests=True,
-        continue_on_error=False
+        continue_on_error=False,
+        continue_on_timeout=True,
+        load_event_name='Page.loadEventFired'
     ):
         """
         Nagivate to a URL.
@@ -150,12 +163,29 @@ class CoreProxy(CommandProxy):
             [page::resource](#pageresource) is cleared before navigating.  Set this to _false_ to
             preserve the ability to retrieve data that was loaded on previous pages.
 
+        - **continue_on_error** (`bool`, optional):
+
+            Whether to continue execution if an error is encountered during page load (e.g.: HTTP
+            4xx/5xx, SSL, TCP connection errors).
+
+        - **continue_on_timeout** (`bool`, optional):
+
+            Whether to continue execution if **load_event_name** is not seen before **timeout**
+            elapses.
+
+        - **load_event_name** (`str`, optional):
+
+            The RPC event to wait for before proceeding to the next command.
+
         #### Returns
         The URL that was loaded (`str`)
         """
 
         if referrer is 'random':
-            referrer = 'http://example.com/{}'.format(uuid4())
+            referrer = '{}/{}'.format(
+                self._referrer_domain.rstrip('/'),
+                uuid4()
+            )
 
         if clear_requests:
             # since we've explicitly navigating, clear the network requests
@@ -170,12 +200,21 @@ class CoreProxy(CommandProxy):
 
         reply = self.tab.page.navigate(uri, referrer=referrer)
 
-        if wait_for_load:
+        if wait_for_load and load_event_name:
             try:
-                self.tab.wait_for('Page.loadEventFired', timeout=timeout)
+                self.tab.wait_for(load_event_name, timeout=timeout)
+
             except exceptions.TimeoutError:
+                if continue_on_timeout:
+                    logging.error('Timed out waiting for {} event after {}ms.'.format(
+                        load_event_name,
+                        timeout
+                    ))
+                else:
+                    raise
+            except exceptions.WebfriendError as e:
                 if continue_on_error:
-                    logging.error('Timed out waiting for page load event.')
+                    logging.error('Got exception while navigating, but proceeding: {}'.format(e))
                 else:
                     raise
 


### PR DESCRIPTION
## webfriend.rpc.page.capture_screenshot

- Updated how `Page.captureScreenshot` is called to make use of the new "clip" parameter introduced in Chromium 61.  This parameter is only added if the (x,y) coordinates of an element matching the given `selector` are >0.  This provides support for taking screenshots of specific page elements (which was broken before this change).  If `x == y == 0`, the old method (using `Emulation.setDeviceMetricsOverride`) is still used to maintain backwards compatibility.

- Added statements at the end of capture_screenshot that reset the viewport and screen size to default dimensions when completed.

## webfriend.rpc.emulation.set_device_metrics_override

- Four kwargs (`mobile_{screen_width,screen_height,position_x,position_y}`) were removed in favor of `screen_width`, `screen_height`, `position_x`, `position_y` to more closely match the `Emulation.setDeviceMetricsOverride` API.

## webfriend.scripting.commands.core

- **configure**: Added `referrer_prefix`, allowing implementers to specify the prefix that is used in the "Referer" tag when making requests.  Defaults to the Github project URL.

- **go**: Added `continue_on_timeout` (default: True) to allow the script to continue execution (or not) if there is a timeout waiting for the load event.  Added `load_event_name`, allowing implementers to specify which RPC event to wait for.  As a result, `continue_on_error` no longer covers timeout exceptions, but still covers all other WebfriendError exceptions.

